### PR TITLE
Work around a pySBOL3 bug

### DIFF
--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -212,16 +212,24 @@ class GenBank_SBOL3_Converter:
         start and end position types (AfterPostion / BeforePosition / ExactPosition).
         :extends: sbol3.Location class
         """
-        GENBANK_RANGE_NS = "http://www.ncbi.nlm.nih.gov/genbank#locationPosition"
-        def __init__(self, sequence: sbol3.Sequence = sbol3.Sequence("autoCreatedSequence"), **kwargs) -> None:
+        # Use the SBOL3 namespace for the type URI as a workaround for
+        # a bug in pySBOL3.
+        # TODO: use genbank namespace when the pySBOL3 bug is fixed
+        # GENBANK_RANGE_NS = "http://www.ncbi.nlm.nih.gov/genbank#locationPosition"
+        GENBANK_RANGE_NS = sbol3.SBOL3_NS + "locationPosition"
+
+        def __init__(self, sequence: sbol3.Sequence = sbol3.Sequence("autoCreatedSequence"),
+                     *, identity: str = None,
+                     type_uri: str = GENBANK_RANGE_NS,
+                     **kwargs) -> None:
             # instantiating sbol3 SequenceFeature object
             # super().__init__(sequence = sequence, identity = None, type_uri = self.GENBANK_RANGE_NS, **kwargs)
-            super().__init__(sequence = sequence, identity = None, type_uri = self.GENBANK_RANGE_NS, **kwargs)
+            super().__init__(sequence = sequence, identity=identity, type_uri = self.GENBANK_RANGE_NS, **kwargs)
             self.start          = sbol3.IntProperty(self, f"{self.GENBANK_RANGE_NS}#start", 0, 1)
             self.end            = sbol3.IntProperty(self, f"{self.GENBANK_RANGE_NS}#end"  , 0, 1)
             # Setting properties for GenBank's location position not settable in any SBOL3 field.
-            self.start_position = sbol3.IntProperty(self, f"{self.GENBANK_RANGE_NS}#start", 0, 1)
-            self.end_position   = sbol3.IntProperty(self, f"{self.GENBANK_RANGE_NS}#end"  , 0, 1)
+            self.start_position = sbol3.IntProperty(self, f"{self.GENBANK_RANGE_NS}#startp", 0, 1)
+            self.end_position   = sbol3.IntProperty(self, f"{self.GENBANK_RANGE_NS}#endp"  , 0, 1)
 
         def accept(self, visitor: Any) -> Any:
             """Invokes `visit_range` on `visitor` with `self` as the only

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -255,7 +255,19 @@ class TestGenBankSBOL3(unittest.TestCase):
     #         print(f"file {genbank_file}")
     #         x = self._test_round_trip_genbank(genbank_file)
     #         print(f"result {x}")
-        
+
+    def test_location_genbank_extension(self):
+        """Test that the Location_GenBank_Extension can be converted
+        from GenBank into SBOL3, and that the resulting SBOL3 file can
+        be loaded.
+        """
+        genbank_file = (
+                Path(__file__).parent / "test_files" / "sbol3_genbank_conversion" / "test_location_types.gb"
+        )
+        self.converter.convert_genbank_to_sbol3(str(genbank_file), write=True)
+        doc = sbol3.Document()
+        doc.read('sbol3.nt', file_format=sbol3.NTRIPLES)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
sbol3.Location does not use keyword arguments to call the parent constructor and therefor cannot be part of a CustomIdentified. Use a type URI that is in the SBOL3 namespace to work around this bug. The proper fix is a type URI in the genbank namespace and inheriting from both sbol3.Location and sbol3.CustomIdentified.

This PR does the following:
* changes the type URI of `Location_GenBank_Extension` to be in the SBOL3 namespace
* handles the `identity` and `type_uri` arguments explicitly in the constructor
* gives unique URIs to `start_position` and `end_position`

The pySBOL3 bug is https://github.com/SynBioDex/pySBOL3/issues/414